### PR TITLE
feat(#0001): provide packer formatting and validation pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/cisagov/pre-commit-packer
+    rev: v0.0.2
+    hooks:
+      - id: packer_fmt
+  - repo: local
+    hooks:
+      - id: packer_validate
+        name: Packer Validate
+        entry: packer validate
+        language: system
+        pass_filenames: false
+        args: 
+          - '.'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,13 @@
 repos:
-  - repo: https://github.com/cisagov/pre-commit-packer
-    rev: v0.0.2
+  - repo: local
     hooks:
       - id: packer_fmt
+        name: Packer Format
+        entry: packer fmt
+        language: system
+        pass_filenames: false
+        args:
+          - '.'
   - repo: local
     hooks:
       - id: packer_validate

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The Packer templates require you to have the following tools available:
 * [Packer](https://www.packer.io/)
 * [VirtualBox](https://www.virtualbox.org/)
 * [Vagrant](https://www.vagrantup.com/)
+* [pre-commit](https://pre-commit.com/)
 
 ## Usage
 The `packer` cli enables you to build the Packer template images and Vagrant box. 
@@ -54,3 +55,6 @@ You can build a single image using the `-only` cli parameter, passing an express
 packer build \
   -only *server-amd64 .
 ```
+
+### Pre-Commit Hooks
+This repository leverages the [pre-commit](https://pre-commit.com/) project to configure Git pre-commit hooks. Currently, we run the `packer fmt` and `packer validate` commands at this time. You can run these checks before committing using the `pre-commit --run all-files` command.

--- a/README.md
+++ b/README.md
@@ -57,4 +57,6 @@ packer build \
 ```
 
 ### Pre-Commit Hooks
-This repository leverages the [pre-commit](https://pre-commit.com/) project to configure Git pre-commit hooks. Currently, we run the `packer fmt` and `packer validate` commands at this time. You can run these checks before committing using the `pre-commit --run all-files` command.
+This repository leverages the [pre-commit](https://pre-commit.com/) project to configure Git pre-commit hooks. Currently, we run the `packer fmt` and `packer validate` commands at this time. 
+
+To install the pre-commit hooks, run the `pre-commit install` command. You can run the checks before committing using the `pre-commit --run all-files` command.


### PR DESCRIPTION
Provided pre-commit hooks for Packer formatting and validation.

Neither of the proposed git hooks provided the behaviour required at this time.

Need to consider:
* Format does not actually fix it, just displays the errors - this feels wrong?
* Not created an ADR for this - but maybe a good time to add ADRs?
* As this repository is private we can't have a Wiki - is there a reason to keep this repo private?