### PR TITLE
feat(#000): enable tasks to be run using batect

### DIFF
--- a/batect
+++ b/batect
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+{
+    set -euo pipefail
+
+    # This file is part of Batect.
+    # Do not modify this file. It will be overwritten next time you upgrade Batect.
+    # You should commit this file to version control alongside the rest of your project. It should not be installed globally.
+    # For more information, visit https://github.com/batect/batect.
+
+    VERSION="0.70.1"
+    CHECKSUM="${BATECT_DOWNLOAD_CHECKSUM:-9329e9e9b414f7f49ddbc6f7fe56bd63c832bce58ce09c0c7f726d7912b06a0e}"
+    DOWNLOAD_URL_ROOT=${BATECT_DOWNLOAD_URL_ROOT:-"https://updates.batect.dev/v1/files"}
+    DOWNLOAD_URL=${BATECT_DOWNLOAD_URL:-"$DOWNLOAD_URL_ROOT/$VERSION/batect-$VERSION.jar"}
+    QUIET_DOWNLOAD=${BATECT_QUIET_DOWNLOAD:-false}
+
+    BATECT_WRAPPER_CACHE_DIR=${BATECT_CACHE_DIR:-"$HOME/.batect/cache"}
+    VERSION_CACHE_DIR="$BATECT_WRAPPER_CACHE_DIR/$VERSION"
+    JAR_PATH="$VERSION_CACHE_DIR/batect-$VERSION.jar"
+    BATECT_WRAPPER_DID_DOWNLOAD=false
+
+    SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    function main() {
+        if ! haveVersionCachedLocally; then
+            download
+            BATECT_WRAPPER_DID_DOWNLOAD=true
+        fi
+
+        checkChecksum
+        runApplication "$@"
+    }
+
+    function haveVersionCachedLocally() {
+        [ -f "$JAR_PATH" ]
+    }
+
+    function download() {
+        checkForCurl
+
+        mkdir -p "$VERSION_CACHE_DIR"
+        temp_file=$(mktemp)
+
+        if [[ $QUIET_DOWNLOAD == 'true' ]]; then
+            curl --silent --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"
+        else
+            echo "Downloading Batect version $VERSION from $DOWNLOAD_URL..."
+            curl -# --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"
+        fi
+
+        mv "$temp_file" "$JAR_PATH"
+    }
+
+    function checkChecksum() {
+        local_checksum=$(getLocalChecksum)
+
+        if [[ "$local_checksum" != "$CHECKSUM" ]]; then
+            echo "The downloaded version of Batect does not have the expected checksum. Delete '$JAR_PATH' and then re-run this script to download it again."
+            exit 1
+        fi
+    }
+
+    function getLocalChecksum() {
+        if [[ "$(uname)" == "Darwin" ]]; then
+            shasum -a 256 "$JAR_PATH" | cut -d' ' -f1
+        else
+            sha256sum "$JAR_PATH" | cut -d' ' -f1
+        fi
+    }
+
+    function runApplication() {
+        checkForJava
+
+        java_version_info=$(getJavaVersionInfo)
+        checkJavaVersion "$java_version_info"
+
+        java_version=$(extractJavaVersion "$java_version_info")
+        java_version_major=$(extractJavaMajorVersion "$java_version")
+
+        if (( java_version_major >= 9 )); then
+            JAVA_OPTS=(--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED)
+        else
+            JAVA_OPTS=()
+        fi
+
+        if [[ "$(uname -o 2>&1)" == "Msys" ]] && hash winpty 2>/dev/null; then
+            GIT_BASH_PTY_WORKAROUND=(winpty)
+        else
+            GIT_BASH_PTY_WORKAROUND=()
+        fi
+
+        BATECT_WRAPPER_SCRIPT_DIR="$SCRIPT_PATH" \
+        BATECT_WRAPPER_CACHE_DIR="$BATECT_WRAPPER_CACHE_DIR" \
+        BATECT_WRAPPER_DID_DOWNLOAD="$BATECT_WRAPPER_DID_DOWNLOAD" \
+        HOSTNAME="$HOSTNAME" \
+        exec \
+            ${GIT_BASH_PTY_WORKAROUND[@]+"${GIT_BASH_PTY_WORKAROUND[@]}"} \
+            java \
+            -Djava.net.useSystemProxies=true \
+            ${JAVA_OPTS[@]+"${JAVA_OPTS[@]}"} \
+            -jar "$JAR_PATH" \
+            "$@"
+    }
+
+    function checkForCurl() {
+        if ! hash curl 2>/dev/null; then
+            echo "curl is not installed or not on your PATH. Please install it and try again." >&2
+            exit 1
+        fi
+    }
+
+    function checkForJava() {
+        if ! hash java 2>/dev/null; then
+            showJavaNotInstalledError
+        fi
+    }
+
+    function showJavaNotInstalledError() {
+        echo "Java is not installed or not on your PATH. Please install it and try again." >&2
+        exit 1
+    }
+
+    function checkJavaVersion() {
+        java_version_info="$1"
+        java_version=$(extractJavaVersion "$java_version_info")
+        java_version_major=$(extractJavaMajorVersion "$java_version")
+        java_version_minor=$(extractJavaMinorVersion "$java_version")
+
+        if (( java_version_major < 1 || ( java_version_major == 1 && java_version_minor <= 7 ) )); then
+            echo "The version of Java that is available on your PATH is version $java_version, but version 1.8 or greater is required."
+            echo "If you have a newer version of Java installed, please make sure your PATH is set correctly."
+            exit 1
+        fi
+
+        if ! javaIs64Bit "$java_version_info"; then
+            echo "The version of Java that is available on your PATH is a 32-bit version, but Batect requires a 64-bit Java runtime."
+            echo "If you have a 64-bit version of Java installed, please make sure your PATH is set correctly."
+            exit 1
+        fi
+    }
+
+    function getJavaVersionInfo() {
+        java -version 2>&1 || showJavaNotInstalledError
+    }
+
+    function extractJavaVersion() {
+        echo "$1" | grep version | sed -En ';s/.* version "([0-9]+)(\.([0-9]+))?.*".*/\1.\3/p;'
+    }
+
+    function extractJavaMajorVersion() {
+        java_version=$1
+
+        echo "${java_version%.*}"
+    }
+
+    function extractJavaMinorVersion() {
+        java_version=$1
+        java_version_minor="${java_version#*.}"
+
+        echo "${java_version_minor:-0}"
+    }
+
+    function javaIs64Bit() {
+        echo "$1" | grep -q '64-[Bb]it'
+    }
+
+    main "$@"
+    exit $?
+}

--- a/batect.cmd
+++ b/batect.cmd
@@ -1,0 +1,413 @@
+@echo off
+rem This file is part of Batect.
+rem Do not modify this file. It will be overwritten next time you upgrade Batect.
+rem You should commit this file to version control alongside the rest of your project. It should not be installed globally.
+rem For more information, visit https://github.com/batect/batect.
+
+setlocal EnableDelayedExpansion
+
+set "version=0.70.1"
+
+if "%BATECT_CACHE_DIR%" == "" (
+    set "BATECT_CACHE_DIR=%USERPROFILE%\.batect\cache"
+)
+
+set "rootCacheDir=!BATECT_CACHE_DIR!"
+set "cacheDir=%rootCacheDir%\%version%"
+set "ps1Path=%cacheDir%\batect-%version%.ps1"
+
+set script=Set-StrictMode -Version 2.0^
+
+$ErrorActionPreference = 'Stop'^
+
+^
+
+$Version='0.70.1'^
+
+^
+
+function getValueOrDefault($value, $default) {^
+
+    if ($value -eq $null) {^
+
+        $default^
+
+    } else {^
+
+        $value^
+
+    }^
+
+}^
+
+^
+
+$DownloadUrlRoot = getValueOrDefault $env:BATECT_DOWNLOAD_URL_ROOT "https://updates.batect.dev/v1/files"^
+
+$UrlEncodedVersion = [Uri]::EscapeDataString($Version)^
+
+$DownloadUrl = getValueOrDefault $env:BATECT_DOWNLOAD_URL "$DownloadUrlRoot/$UrlEncodedVersion/batect-$UrlEncodedVersion.jar"^
+
+$ExpectedChecksum = getValueOrDefault $env:BATECT_DOWNLOAD_CHECKSUM '9329e9e9b414f7f49ddbc6f7fe56bd63c832bce58ce09c0c7f726d7912b06a0e'^
+
+^
+
+$RootCacheDir = getValueOrDefault $env:BATECT_CACHE_DIR "$env:USERPROFILE\.batect\cache"^
+
+$VersionCacheDir = "$RootCacheDir\$Version"^
+
+$JarPath = "$VersionCacheDir\batect-$Version.jar"^
+
+$DidDownload = 'false'^
+
+^
+
+function main() {^
+
+    if (-not (haveVersionCachedLocally)) {^
+
+        download^
+
+        $DidDownload = 'true'^
+
+    }^
+
+^
+
+    checkChecksum^
+
+    runApplication @args^
+
+}^
+
+^
+
+function haveVersionCachedLocally() {^
+
+    Test-Path $JarPath^
+
+}^
+
+^
+
+function download() {^
+
+    Write-Output "Downloading Batect version $Version from $DownloadUrl..."^
+
+^
+
+    createCacheDir^
+
+^
+
+    $oldProgressPreference = $ProgressPreference^
+
+^
+
+    try {^
+
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12^
+
+^
+
+        # Turn off the progress bar to significantly reduce download times - see https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251165868^
+
+        $ProgressPreference = 'SilentlyContinue'^
+
+^
+
+        Invoke-WebRequest -Uri $DownloadUrl -OutFile $JarPath ^| Out-Null^
+
+    } catch {^
+
+        $Message = $_.Exception.Message^
+
+^
+
+        Write-Host -ForegroundColor Red "Downloading failed with error: $Message"^
+
+        exit 1^
+
+    } finally {^
+
+        $ProgressPreference = $oldProgressPreference^
+
+    }^
+
+}^
+
+^
+
+function checkChecksum() {^
+
+    $localChecksum = (Get-FileHash -Algorithm 'SHA256' $JarPath).Hash.ToLower()^
+
+^
+
+    if ($localChecksum -ne $expectedChecksum) {^
+
+        Write-Host -ForegroundColor Red "The downloaded version of Batect does not have the expected checksum. Delete '$JarPath' and then re-run this script to download it again."^
+
+        exit 1^
+
+    }^
+
+}^
+
+^
+
+function createCacheDir() {^
+
+    if (-not (Test-Path $VersionCacheDir)) {^
+
+        New-Item -ItemType Directory -Path $VersionCacheDir ^| Out-Null^
+
+    }^
+
+}^
+
+^
+
+function runApplication() {^
+
+    $java = findJava^
+
+    $javaVersion = checkJavaVersion $java^
+
+^
+
+    if ($javaVersion.Major -ge 9) {^
+
+        $javaArgs = @("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "java.base/java.io=ALL-UNNAMED")^
+
+    } else {^
+
+        $javaArgs = @()^
+
+    }^
+
+^
+
+    $combinedArgs = $javaArgs + @("-Djava.net.useSystemProxies=true", "-jar", $JarPath) + $args^
+
+    $env:HOSTNAME = $env:COMPUTERNAME^
+
+    $env:BATECT_WRAPPER_CACHE_DIR = $RootCacheDir^
+
+    $env:BATECT_WRAPPER_DID_DOWNLOAD = $DidDownload^
+
+^
+
+    $info = New-Object System.Diagnostics.ProcessStartInfo^
+
+    $info.FileName = $java.Source^
+
+    $info.Arguments = combineArgumentsToString($combinedArgs)^
+
+    $info.RedirectStandardError = $false^
+
+    $info.RedirectStandardOutput = $false^
+
+    $info.UseShellExecute = $false^
+
+^
+
+    $process = New-Object System.Diagnostics.Process^
+
+    $process.StartInfo = $info^
+
+    $process.Start() ^| Out-Null^
+
+    $process.WaitForExit()^
+
+^
+
+    exit $process.ExitCode^
+
+}^
+
+^
+
+function findJava() {^
+
+    $java = Get-Command "java" -ErrorAction SilentlyContinue^
+
+^
+
+    if ($java -eq $null) {^
+
+        Write-Host -ForegroundColor Red "Java is not installed or not on your PATH. Please install it and try again."^
+
+        exit 1^
+
+    }^
+
+^
+
+    return $java^
+
+}^
+
+^
+
+function checkJavaVersion([System.Management.Automation.CommandInfo]$java) {^
+
+    $versionInfo = getJavaVersionInfo $java^
+
+    $rawVersion = getJavaVersion $versionInfo^
+
+    $parsedVersion = New-Object Version -ArgumentList $rawVersion^
+
+    $minimumVersion = "1.8"^
+
+^
+
+    if ($parsedVersion -lt (New-Object Version -ArgumentList $minimumVersion)) {^
+
+        Write-Host -ForegroundColor Red "The version of Java that is available on your PATH is version $rawVersion, but version $minimumVersion or greater is required."^
+
+        Write-Host -ForegroundColor Red "If you have a newer version of Java installed, please make sure your PATH is set correctly."^
+
+        exit 1^
+
+    }^
+
+^
+
+    if (-not ($versionInfo -match "64\-[bB]it")) {^
+
+        Write-Host -ForegroundColor Red "The version of Java that is available on your PATH is a 32-bit version, but Batect requires a 64-bit Java runtime."^
+
+        Write-Host -ForegroundColor Red "If you have a 64-bit version of Java installed, please make sure your PATH is set correctly."^
+
+        exit 1^
+
+    }^
+
+^
+
+    return $parsedVersion^
+
+}^
+
+^
+
+function getJavaVersionInfo([System.Management.Automation.CommandInfo]$java) {^
+
+    $info = New-Object System.Diagnostics.ProcessStartInfo^
+
+    $info.FileName = $java.Source^
+
+    $info.Arguments = "-version"^
+
+    $info.RedirectStandardError = $true^
+
+    $info.RedirectStandardOutput = $true^
+
+    $info.UseShellExecute = $false^
+
+^
+
+    $process = New-Object System.Diagnostics.Process^
+
+    $process.StartInfo = $info^
+
+    $process.Start() ^| Out-Null^
+
+    $process.WaitForExit()^
+
+^
+
+    $stderr = $process.StandardError.ReadToEnd()^
+
+    return $stderr^
+
+}^
+
+^
+
+function getJavaVersion([String]$versionInfo) {^
+
+    $versionLine = ($versionInfo -split [Environment]::NewLine)[0]^
+
+^
+
+    if (-not ($versionLine -match "version `"([0-9]+)(\.([0-9]+))?.*`"")) {^
+
+        Write-Error "Java reported a version that does not match the expected format: $versionLine"^
+
+    }^
+
+^
+
+    $major = $Matches.1^
+
+^
+
+    if ($Matches.Count -ge 3) {^
+
+        $minor = $Matches.3^
+
+    } else {^
+
+        $minor = "0"^
+
+    }^
+
+^
+
+    return "$major.$minor"^
+
+}^
+
+^
+
+function combineArgumentsToString([Object[]]$arguments) {^
+
+    $combined = @()^
+
+^
+
+    $arguments ^| %% { $combined += escapeArgument($_) }^
+
+^
+
+    return $combined -join " "^
+
+}^
+
+^
+
+function escapeArgument([String]$argument) {^
+
+    return '"' + $argument.Replace('"', '"""') + '"'^
+
+}^
+
+^
+
+main @args
+
+if not exist "%cacheDir%" (
+    mkdir "%cacheDir%"
+)
+
+echo !script! > "%ps1Path%"
+
+set BATECT_WRAPPER_SCRIPT_DIR=%~dp0
+
+rem Why do we explicitly exit?
+rem cmd.exe appears to read this script one line at a time and then executes it.
+rem If we modify the script while it is still running (eg. because we're updating it), then cmd.exe does all kinds of odd things
+rem because it continues execution from the next byte (which was previously the end of the line).
+rem By explicitly exiting on the same line as starting the application, we avoid these issues as cmd.exe has already read the entire
+rem line before we start the application and therefore will always exit.
+
+rem Why do we set PSModulePath?
+rem See issue #627
+set "PSModulePath="
+powershell.exe -ExecutionPolicy Bypass -NoLogo -NoProfile -File "%ps1Path%" %* && exit /b 0 || exit /b !ERRORLEVEL!
+
+rem What's this for?
+rem This is so the tests for the wrapper has a way to ensure that the line above terminates the script correctly.
+echo WARNING: you should never see this, and if you do, then Batect's wrapper script has a bug

--- a/batect.yml
+++ b/batect.yml
@@ -1,0 +1,13 @@
+containers:
+  shellcheck:
+    image: koalaman/shellcheck:v0.7.2
+    volumes:
+      - local: ${PWD}
+        container: /mnt
+
+tasks:
+  analyse_utils_shellscripts:
+    description: Analyse utility shellscripts
+    run:
+      container: shellcheck
+      command: utils/get_batect.sh

--- a/utils/get_batect.sh
+++ b/utils/get_batect.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Author: Catosplace Engineering <engineering@catosplace.co.nz>
+#
+#/ Usage: SCRIPTNAME [OPTIONS]... [ARGUEMENTS]...
+#/
+#/
+#/ OPTIONS
+#/  -h, --help
+#/              Print this help message
+#/
+#/ EXAMPLES
+#/
+
+#{{{ Bash settings
+# abort on nonzero exitstatus
+set -o errexit
+# abort on unbound variable
+set -o nounset
+# abort on errors within pipes
+set -o pipefail
+# set -o xtrace
+#}}}
+
+#{{{ Variables
+# declare script_name
+declare script_dir
+# script_name=$(basename "${0}")
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+IFS=$'\t\n' # Split on newlines and tabs (but not on spaces)
+BATECT_VERSION=0.70.1
+#}}}
+
+main() {
+  # check_args "${@}"
+  get_bactect
+}
+
+#{{{ Helper functions
+
+get_bactect() {
+  wget -O "${script_dir}"/../batect https://github.com/batect/batect/releases/download/$BATECT_VERSION/batect
+  wget -O "${script_dir}"/../batect.cmd https://github.com/batect/batect/releases/download/$BATECT_VERSION/batect.cmd
+}
+
+#}}}
+
+main "${@}"


### PR DESCRIPTION
Added [Batect](https://batect.dev/) to the application.

To use Batect there is a dependency on Java at this time - this should be removed at version 1.0.0, which will improve the purpose.

This implementation to test uses the [shellcheck](https://github.com/koalaman/shellcheck) container to analyse the script written to download Batect to the repository.