### PR TITLE
feat(#004): provide ability to record architecure decisions within the project

### DIFF
--- a/batect.yml
+++ b/batect.yml
@@ -1,11 +1,37 @@
 containers:
+  
+  adr-tools:
+    image: rdhaliwal/adr-tools:3.0.0
+    volumes:
+      - local: <{batect.project_directory}/docs/architecture/decisions
+        container: /doc/adr    
+  
   shellcheck:
     image: koalaman/shellcheck-alpine:v0.7.2
     volumes:
-      - local: ${PWD}
+      - local: <{batect.project_directory}
         container: /mnt
 
 tasks:
+
+  adr:
+    description: Run arbitary ADR tools command
+    run:
+      container: adr-tools
+      command: adr 
+
+  new_adr:
+    description: Generate a new ADR file
+    run:
+      container: adr-tools
+      command: adr new 
+
+  generate_adr_toc:
+    description: Generate the ADR table of contents
+    run:
+      container: adr-tools
+      command: sh -c "adr generate toc -i /doc/adr/intro.md -o /doc/adr/outro.md > /doc/adr/README.md"
+
   analyse_utils_shellscripts:
     description: Analyse utility shellscripts
     run:

--- a/docs/architecture/decisions/0001-record-architecture-decisions.md
+++ b/docs/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2021-05-29
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,6 @@
+# Architecture Decision Records
+
+List of current Architecture Decisions
+* [1. Record architecture decisions](0001-record-architecture-decisions.md)
+
+This file was generated using the `.batect generate_adr_toc` command

--- a/docs/architecture/decisions/intro.md
+++ b/docs/architecture/decisions/intro.md
@@ -1,0 +1,1 @@
+List of current Architecture Decisions

--- a/docs/architecture/decisions/outro.md
+++ b/docs/architecture/decisions/outro.md
@@ -1,0 +1,1 @@
+This file was generated using the `.batect generate_adr_toc` command


### PR DESCRIPTION
Added [adr-tools-docker](https://github.com/rdhaliwal/adr-tools-docker) container to provide the abilitiy to record architecture decision records based on [adr-tools](https://github.com/npryce/adr-tools)

Provides abilities with `batect` to
* Initialise the ADR directory
* Run an arbitrary ADR command using a `batect` command - `./batect adr -- help`
* Generate a new ADR file - `./batect generate_adr_toc -- New ADR`
* Generate a Table of Contents, using into and outro text -- `./batect generate_adr_toc`

This appears to work well as implementation and is more support for `batect` as an option.